### PR TITLE
chore: streamlined docs and internal naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,38 @@
 
 Gently fails test runs if the console was used during them.
 
+## Why?
+
+Logging to the console during tests can be a sign of:
+
+- 🚫 warnings from third-party libraries such as React for improper usage
+- 🤕 temporary code that shouldn't be checked into your project
+- 📢 unnecessary spam in your tests window
+
+This little library throws an error after each test if a console method was called during it.
+It's got some nifty features:
+
+- 📊 Summary of which methods are called with calling arguments
+- 🛫 Failures are thrown _after_ tests finish, so your tests will fail normally if they should
+
+```plaintext
+stdout | src/index.test.ts > index > example test that console.logs
+Whoopsies!
+
+ ❯ src/index.test.ts (4)
+   ❯ index (4)
+     × example test that console.logs
+       ⠙ [ afterEach ]
+     ✓ example test that does not console.log
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯- Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯-
+
+ FAIL  src/index.test.ts > index > example test that console.logs
+Error: Oh no! Your test called the following console method:
+  * log (1 call)
+    > Call 0: "Whoopsies!"
+```
+
 ## Usage
 
 `console-fail-test` is meant to support any _(test framework)_ & _(spy library)_ combination.
@@ -20,23 +52,9 @@ For example, in a Jest config:
 setupFilesAfterEnv: ["console-fail-test/setup.js"],
 ```
 
-Alternately, you can manually call the Node API before your tests:
-
-```js
-// setup
-require("console-fail-test").cft();
-```
-
 ### Test Frameworks
 
-Test frameworks that are ✨ auto-detectable can be supported by just running `console-fail-test/setup.js` before tests.
-For others, use the Node API with their API request:
-
-```js
-require("console-fail-test").cft({
-  testFramework: require("ava"),
-});
-```
+See the _Documentation_ link for each supported framework for how to set up console-fail-test with that framework.
 
 <table>
   <thead>
@@ -51,7 +69,7 @@ require("console-fail-test").cft({
     <tr>
       <td>Ava</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
+        ✅️
       </td>
       <td>
         <code>require("ava")</code>
@@ -65,8 +83,8 @@ require("console-fail-test").cft({
     <tr>
       <td>Mocha</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
-        <span aria-label="auto detectable" role="img">✨</span>
+        ✅️
+        ✨
       </td>
       <td>
         <code>"mocha"</code>
@@ -80,8 +98,8 @@ require("console-fail-test").cft({
     <tr>
       <td>Jasmine</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
-        <span aria-label="auto detectable" role="img">✨</span>
+        ✅️
+        ✨
       </td>
       <td>
         <code>"jasmine"</code>
@@ -95,8 +113,8 @@ require("console-fail-test").cft({
     <tr>
       <td>Jest</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
-        <span aria-label="auto detectable" role="img">✨</span>
+        ✅️
+        ✨
       </td>
       <td>
         <code>"jest"</code>
@@ -110,7 +128,7 @@ require("console-fail-test").cft({
     <tr>
       <td>lab</td>
       <td>
-        <span aria-label="supported" role="img">✅</span>
+        ✅
       </td>
       <td>
         <code>exports.lab</code>
@@ -124,7 +142,7 @@ require("console-fail-test").cft({
     <tr>
       <td>node-tap</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
+        ✅️
       </td>
       <td>
         <code>require("node-tap")</code>
@@ -137,10 +155,8 @@ require("console-fail-test").cft({
     </tr>
     <tr>
       <td>Cypress</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td />
+      <td>⚙️</td>
+      <td></td>
       <td>
         <a href="https://github.com/JoshuaKGoldberg/console-fail-test/issues/199">
           <code>/issues/199</code>
@@ -149,10 +165,8 @@ require("console-fail-test").cft({
     </tr>
     <tr>
       <td>QUnit</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td />
+      <td>⚙️</td>
+      <td></td>
       <td>
         <a href="https://github.com/JoshuaKGoldberg/console-fail-test/issues/19">
           <code>/issues/19</code>
@@ -161,10 +175,8 @@ require("console-fail-test").cft({
     </tr>
     <tr>
       <td>Playwright</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td />
+      <td>⚙️</td>
+      <td></td>
       <td>
         <a href="https://github.com/JoshuaKGoldberg/console-fail-test/issues/198">
           <code>/issues/198</code>
@@ -173,10 +185,8 @@ require("console-fail-test").cft({
     </tr>
     <tr>
       <td>tape</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td />
+      <td>⚙️</td>
+      <td></td>
       <td>
         <a href="https://github.com/JoshuaKGoldberg/console-fail-test/issues/17">
           <code>/issues/17</code>
@@ -185,10 +195,8 @@ require("console-fail-test").cft({
     </tr>
     <tr>
       <td>TestCafe</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td />
+      <td>⚙️</td>
+      <td></td>
       <td>
         <a href="https://github.com/JoshuaKGoldberg/console-fail-test/issues/15">
           <code>/issues/15</code>
@@ -197,10 +205,8 @@ require("console-fail-test").cft({
     </tr>
     <tr>
       <td>Vitest</td>
-      <td>
-        <span aria-label="not yet supported" role="img">⚙️</span>
-      </td>
-      <td />
+      <td>⚙️</td>
+      <td></td>
       <td>
         <a href="https://github.com/JoshuaKGoldberg/console-fail-test/issues/197">
           <code>/issues/197</code>
@@ -210,10 +216,9 @@ require("console-fail-test").cft({
   </tbody>
 </table>
 
-> See [open test framework support issues](https://github.com/JoshuaKGoldberg/console-fail-test/issues?q=is%3Aissue+is%3Aopen+label%3A%22test+framework+support%22) for progress!
-
 ### Spy Libraries
 
+If your test framework provides its own spy library, console-fail-test will by default use that library.
 If a supported spy library isn't detected, an internal fallback will be used to spy on `console` methods.
 
 You can request a specific test library using the Node API with its API request:
@@ -238,7 +243,7 @@ require("console-fail-test").cft({
     <tr>
       <td>Jasmine</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
+        ✅️
       </td>
       <td>
         <code>"jasmine"</code>
@@ -249,15 +254,15 @@ require("console-fail-test").cft({
         </a>
       </td>
       <td>
-        <a href="./docs/Jasmine.md">
-          <code>Jasmine.md</code>
+        <a href="./docs/Jasmine.md#spies">
+          <code>Jasmine.md#spies</code>
         </a>
       </td>
     </tr>
     <tr>
       <td>Jest</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
+        ✅️
       </td>
       <td>
         <code>"jest"</code>
@@ -268,15 +273,15 @@ require("console-fail-test").cft({
         </a>
       </td>
       <td>
-        <a href="./docs/Jest.md">
-          <code>Jest.md</code>
+        <a href="./docs/Jest.md#spies">
+          <code>Jest.md#spies</code>
         </a>
       </td>
     </tr>
     <tr>
       <td>Sinon</td>
       <td>
-        <span aria-label="supported" role="img">✅️</span>
+        ✅️
       </td>
       <td>
         <code>require("sinon")</code>
@@ -287,8 +292,8 @@ require("console-fail-test").cft({
         </a>
       </td>
       <td>
-        <a href="./docs/Sinon.md">
-          <code>Sinon.md</code>
+        <a href="./docs/Sinon.md#spies">
+          <code>Sinon.md#spies</code>
         </a>
       </td>
     </tr>
@@ -307,29 +312,11 @@ require("console-fail-test").cft({
 });
 ```
 
-## Why?
-
-Logging to the console during tests can be a sign of
-
-- 🚫 warnings from third-party libraries such as React for improper usage
-- 🤕 temporary code that shouldn't be checked into your project
-- 📢 unnecessary spam in your tests window
-
-This little library throws an error after each test if a console method was called during it.
-It's got some nifty features:
-
-- 📊 Summary of which methods are called with calling arguments
-- 🛫 Failures are thrown _after_ tests finish, so your tests will fail normally if they should
-
-Look how fancy the terminal output is with Jest!
-
-![Terminal output showing details on each console call failing a test](./images/sample.png)
-
 ## Development
 
 Requires:
 
-- [Node.js](https://nodejs.org) >10 (LTS)
+- [Node.js](https://nodejs.org) >14 (LTS)
 - [Yarn](https://yarnpkg.com/en)
 
 After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo):

--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,5 @@
 {
   "dictionaries": ["typescript"],
   "ignorePaths": ["lib", "node_modules", "**/*.d.ts", "**/*.js"],
-  "words": ["commitlint"]
+  "words": ["commitlint", "whoopsies"]
 }

--- a/src/cft.ts
+++ b/src/cft.ts
@@ -1,38 +1,43 @@
 import { createComplaint } from "./complaining";
 import { consoleMethodNames } from "./console";
 import { setDefaults } from "./defaults";
-import { selectTestEnvironment } from "./environments/selectTestEnvironments";
-import { getSpyFactory } from "./spies/selectSpyFactory";
-import { MethodCall, MethodSpy } from "./spies/spyTypes";
+import { selectTestFramework as selectTestFramework } from "./environments/selectTestFramework";
+import { TestComplaint } from "./environments/testEnvironmentTypes";
+import { selectSpyFactory } from "./spies/selectSpyFactory";
+import { SpyCallArgs, MethodSpy } from "./spies/spyTypes";
 import { CftRequest } from "./types";
+
+const defaultReportComplaint = ({ error }: TestComplaint) => {
+  throw error;
+};
 
 export const cft = (rawRequest?: Partial<CftRequest>) => {
   const request = setDefaults(rawRequest);
-  const spyFactory = getSpyFactory(request);
-  const testEnvironment = selectTestEnvironment(request);
+  const spyFactory = selectSpyFactory(request);
+  const testFramework = selectTestFramework(request);
   const methodSpies: Record<string, MethodSpy> = {};
   const relevantMethodNames = consoleMethodNames.filter((name) => !request.console[name]);
 
-  testEnvironment.before(() => {
+  // Before each test, we spy on the console's methods
+  testFramework.beforeEach(() => {
     for (const methodName of relevantMethodNames) {
       methodSpies[methodName] = spyFactory(console, methodName);
     }
   });
 
-  testEnvironment.after(({ reportComplaint }) => {
-    const methodsWithCalls: [keyof Console, MethodCall[]][] = [];
+  // After each test, we collect the spied method calls, reporting on any found
+  testFramework.afterEach(({ reportComplaint = defaultReportComplaint } = {}) => {
+    const methodsWithCalls: [keyof Console, SpyCallArgs[]][] = [];
 
     for (const methodName of relevantMethodNames) {
       const spy = methodSpies[methodName];
-      const calls = testEnvironment.filterMethodCalls({
-        methodCalls: spy.getCalls(),
-        methodName,
-      });
+      const methodCalls = spy.getCalls();
+      const filteredCalls = testFramework.mapSpyCalls?.({ methodCalls, methodName }) ?? methodCalls;
 
       spy.restore();
 
-      if (calls.length !== 0) {
-        methodsWithCalls.push([methodName, calls]);
+      if (filteredCalls.length !== 0) {
+        methodsWithCalls.push([methodName, filteredCalls]);
       }
     }
 

--- a/src/complaining.ts
+++ b/src/complaining.ts
@@ -1,9 +1,9 @@
 import { TestComplaint } from "./environments/testEnvironmentTypes";
-import { MethodCall } from "./spies/spyTypes";
+import { SpyCallArgs } from "./spies/spyTypes";
 
 const lineThreshold = 3;
 
-const formatMethodComplaint = ([methodName, calls]: [keyof Console, MethodCall[]]) => {
+const formatMethodComplaint = ([methodName, calls]: [keyof Console, SpyCallArgs[]]) => {
   const summary = `  * ${methodName} (${calls.length} call${calls.length === 1 ? "" : "s"})`;
 
   const lines = calls
@@ -17,18 +17,18 @@ const formatMethodComplaint = ([methodName, calls]: [keyof Console, MethodCall[]
   return `${summary}\n${lines.map((line) => `    > Call ${line}`).join("\n")}`;
 };
 
-export const formatComplaintLineWithIndex = (call: MethodCall, i: number) =>
+export const formatComplaintLineWithIndex = (call: SpyCallArgs, i: number) =>
   `${i}: ${formatComplaintCall(call)}`;
 
-export const formatComplaintCall = (call: MethodCall) =>
-  call.args.map(formatComplaintLineArg).join(", ");
+export const formatComplaintCall = (call: SpyCallArgs) =>
+  call.map(formatComplaintLineArg).join(", ");
 
 export const formatComplaintLineArg = (arg: unknown) => {
   return JSON.stringify(arg) || JSON.stringify(`${arg}`);
 };
 
 export const createComplaint = (
-  methodsWithCalls: [keyof Console, MethodCall[]][],
+  methodsWithCalls: [keyof Console, SpyCallArgs[]][],
 ): TestComplaint => {
   const methodComplaints = methodsWithCalls.map(formatMethodComplaint).join("\n");
   const s = methodsWithCalls.length === 1 ? "" : "s";
@@ -42,8 +42,8 @@ export const createComplaint = (
   return {
     error,
     methodComplaints: methodsWithCalls.map(([methodName, methodCalls]) => ({
-      methodName,
       methodCalls,
+      methodName,
     })),
   };
 };

--- a/src/environments/ava.ts
+++ b/src/environments/ava.ts
@@ -1,6 +1,4 @@
-import { CftRequest } from "../types";
-
-import { TestAfterHooks, TestEnvironmentGetter } from "./testEnvironmentTypes";
+import { TestFrameworkSelector } from "./testEnvironmentTypes";
 
 declare interface Ava {
   afterEach(callback: Function): void;
@@ -28,22 +26,17 @@ const isAva = (testFramework: unknown): testFramework is Ava => {
   );
 };
 
-export const getAvaEnvironment: TestEnvironmentGetter = ({ testFramework }: CftRequest) => {
+export const selectAvaEnvironment: TestFrameworkSelector = ({ testFramework }) => {
   if (!isAva(testFramework)) {
     return undefined;
   }
 
   return {
-    after(callback: (afterHooks: TestAfterHooks) => void) {
+    afterEach: (callback) => {
       testFramework.afterEach(() => {
-        callback({
-          reportComplaint: ({ error }) => {
-            throw error;
-          },
-        });
+        callback();
       });
     },
-    before: testFramework.beforeEach,
-    filterMethodCalls: ({ methodCalls }) => methodCalls,
+    beforeEach: testFramework.beforeEach,
   };
 };

--- a/src/environments/jasmine.ts
+++ b/src/environments/jasmine.ts
@@ -1,4 +1,4 @@
-import { TestAfterHooks, TestEnvironmentGetter } from "./testEnvironmentTypes";
+import { TestFrameworkSelector } from "./testEnvironmentTypes";
 
 declare const afterEach: (callback: () => void) => void;
 declare const beforeEach: (callback: () => void) => void;
@@ -6,7 +6,7 @@ declare const jasmine: {
   Spec: unknown;
 };
 
-export const getJasmineEnvironment: TestEnvironmentGetter = () => {
+export const selectJasmineEnvironment: TestFrameworkSelector = () => {
   if (
     typeof afterEach === "undefined" ||
     typeof beforeEach === "undefined" ||
@@ -17,7 +17,7 @@ export const getJasmineEnvironment: TestEnvironmentGetter = () => {
   }
 
   return {
-    after(callback: (afterHooks: TestAfterHooks) => void) {
+    afterEach: (callback) => {
       afterEach(() => {
         callback({
           reportComplaint({ error }) {
@@ -29,9 +29,8 @@ export const getJasmineEnvironment: TestEnvironmentGetter = () => {
         });
       });
     },
-    before: (callback: () => void) => {
+    beforeEach: (callback) => {
       beforeEach(callback);
     },
-    filterMethodCalls: ({ methodCalls }) => methodCalls,
   };
 };

--- a/src/environments/jest.ts
+++ b/src/environments/jest.ts
@@ -1,10 +1,10 @@
-import { TestAfterHooks, TestEnvironmentGetter } from "./testEnvironmentTypes";
+import { TestFrameworkSelector } from "./testEnvironmentTypes";
 
 declare const afterEach: (callback: () => void) => void;
 declare const beforeEach: (callback: () => void) => void;
 declare const jest: unknown;
 
-export const getJestEnvironment: TestEnvironmentGetter = () => {
+export const selectJestEnvironment: TestFrameworkSelector = () => {
   if (
     typeof afterEach === "undefined" ||
     typeof beforeEach === "undefined" ||
@@ -13,31 +13,23 @@ export const getJestEnvironment: TestEnvironmentGetter = () => {
     return undefined;
   }
 
-  /* eslint-disable @typescript-eslint/no-empty-function */
-  let afterEachCallback = () => {};
-  let beforeEachCallback = () => {};
-  /* eslint-enable @typescript-eslint/no-empty-function */
+  let afterEachCallback: (() => void) | undefined;
+  let beforeEachCallback: (() => void) | undefined;
 
   afterEach(() => {
-    afterEachCallback();
+    afterEachCallback?.();
   });
 
   beforeEach(() => {
-    beforeEachCallback();
+    beforeEachCallback?.();
   });
 
   return {
-    after(callback: (afterHooks: TestAfterHooks) => void) {
-      afterEachCallback = () =>
-        callback({
-          reportComplaint({ error }) {
-            throw error;
-          },
-        });
+    afterEach: (callback) => {
+      afterEachCallback = callback;
     },
-    before: (callback: () => void) => {
+    beforeEach: (callback) => {
       beforeEachCallback = callback;
     },
-    filterMethodCalls: ({ methodCalls }) => methodCalls,
   };
 };

--- a/src/environments/lab.ts
+++ b/src/environments/lab.ts
@@ -1,6 +1,4 @@
-import { CftRequest } from "../types";
-
-import { TestAfterHooks, TestEnvironmentGetter } from "./testEnvironmentTypes";
+import { TestFrameworkSelector } from "./testEnvironmentTypes";
 
 declare interface Lab {
   afterEach(callback: Function): void;
@@ -22,13 +20,13 @@ const isLab = (testFramework: unknown): testFramework is Lab => {
   );
 };
 
-export const getLabEnvironment: TestEnvironmentGetter = ({ testFramework }: CftRequest) => {
+export const selectLabEnvironment: TestFrameworkSelector = ({ testFramework }) => {
   if (!isLab(testFramework)) {
     return undefined;
   }
 
   return {
-    after(callback: (afterHooks: TestAfterHooks) => void) {
+    afterEach: (callback) => {
       testFramework.afterEach(() => {
         callback({
           reportComplaint({ error }) {
@@ -37,7 +35,6 @@ export const getLabEnvironment: TestEnvironmentGetter = ({ testFramework }: CftR
         });
       });
     },
-    before: testFramework.beforeEach,
-    filterMethodCalls: ({ methodCalls }) => methodCalls,
+    beforeEach: testFramework.beforeEach,
   };
 };

--- a/src/environments/mocha.ts
+++ b/src/environments/mocha.ts
@@ -1,4 +1,4 @@
-import { TestAfterHooks, TestEnvironmentGetter } from "./testEnvironmentTypes";
+import { TestFrameworkSelector } from "./testEnvironmentTypes";
 
 declare const afterEach: (callback: (this: Mocha) => void) => void;
 declare const beforeEach: (callback: (this: Mocha) => void) => void;
@@ -12,7 +12,7 @@ declare interface Mocha {
   };
 }
 
-export const getMochaEnvironment: TestEnvironmentGetter = () => {
+export const selectMochaEnvironment: TestFrameworkSelector = () => {
   // Until there is some kind of global `mocha` variable that can be referenced,
   // we check the stringified versions of its used hook methods
   // See https://github.com/JoshuaKGoldberg/console-fail-test/issues/10
@@ -26,7 +26,7 @@ export const getMochaEnvironment: TestEnvironmentGetter = () => {
   }
 
   return {
-    after(callback: (afterHooks: TestAfterHooks) => void) {
+    afterEach: (callback) => {
       afterEach(function (this: Mocha) {
         if (this.currentTest.state !== "passed") {
           return;
@@ -40,8 +40,8 @@ export const getMochaEnvironment: TestEnvironmentGetter = () => {
         });
       });
     },
-    before: beforeEach,
-    filterMethodCalls: ({ methodCalls, methodName }) => {
+    beforeEach,
+    mapSpyCalls: ({ methodCalls, methodName }) => {
       if (methodCalls.length === 0 || methodName !== "log") {
         return methodCalls;
       }
@@ -50,7 +50,7 @@ export const getMochaEnvironment: TestEnvironmentGetter = () => {
       // The last log, if it exists, might be the spec reporter
       // It'd be nice to have more info on what the reporter has logged...
       const lastCall = methodCalls[methodCalls.length - 1];
-      const first = lastCall.args[0];
+      const first = lastCall[0];
       if (typeof first === "string" && first.startsWith("  ")) {
         methodCalls = methodCalls.slice(0, methodCalls.length - 1);
       }

--- a/src/environments/selectTestFramework.ts
+++ b/src/environments/selectTestFramework.ts
@@ -1,35 +1,35 @@
 import { CftRequest, SupportedTestFramework } from "../types";
 
-import { getAvaEnvironment } from "./ava";
-import { getJasmineEnvironment } from "./jasmine";
-import { getJestEnvironment } from "./jest";
-import { getLabEnvironment } from "./lab";
-import { getMochaEnvironment } from "./mocha";
-import { getNodeTapEnvironment } from "./nodeTap";
-import { TestEnvironmentGetter } from "./testEnvironmentTypes";
+import { selectAvaEnvironment } from "./ava";
+import { selectJasmineEnvironment } from "./jasmine";
+import { selectJestEnvironment } from "./jest";
+import { selectLabEnvironment } from "./lab";
+import { selectMochaEnvironment } from "./mocha";
+import { selectNodeTapEnvironment } from "./nodeTap";
+import { TestFrameworkSelector } from "./testEnvironmentTypes";
 
-const testEnvironmentsByName = new Map<SupportedTestFramework, TestEnvironmentGetter>([
-  ["mocha", getMochaEnvironment],
-  ["jest", getJestEnvironment],
-  ["jasmine", getJasmineEnvironment],
+const testEnvironmentsByName = new Map<SupportedTestFramework, TestFrameworkSelector>([
+  ["jasmine", selectJasmineEnvironment],
+  ["jest", selectJestEnvironment],
+  ["mocha", selectMochaEnvironment],
 ]);
 
-const detectableTestEnvironmentGetters: TestEnvironmentGetter[] = [
+const detectableTestEnvironmentSelectors: TestFrameworkSelector[] = [
   // These environments only work with received modules, so they should come first
-  getAvaEnvironment,
-  getLabEnvironment,
-  getNodeTapEnvironment,
+  selectAvaEnvironment,
+  selectLabEnvironment,
+  selectNodeTapEnvironment,
 
   // Jest should come before Jasmine because Jest includes a monkey-patched Jasmine
-  getJestEnvironment,
-  getJasmineEnvironment,
+  selectJestEnvironment,
+  selectJasmineEnvironment,
 
   // Mocha should be last because it's difficult to accurately detect
   // See https://github.com/JoshuaKGoldberg/console-fail-test/issues/10
-  getMochaEnvironment,
+  selectMochaEnvironment,
 ];
 
-export const selectTestEnvironment = (request: CftRequest) => {
+export const selectTestFramework = (request: CftRequest) => {
   // If a test environment is requested by name, it must exist
   if (typeof request.testFramework === "string") {
     const getter = testEnvironmentsByName.get(request.testFramework);
@@ -50,7 +50,7 @@ export const selectTestEnvironment = (request: CftRequest) => {
   }
 
   // Otherwise, attempt to auto-detect an active one
-  for (const testEnvironmentGetter of detectableTestEnvironmentGetters) {
+  for (const testEnvironmentGetter of detectableTestEnvironmentSelectors) {
     const environment = testEnvironmentGetter(request);
 
     if (environment !== undefined) {

--- a/src/environments/testEnvironmentTypes.ts
+++ b/src/environments/testEnvironmentTypes.ts
@@ -1,20 +1,39 @@
-import { MethodCall } from "../spies/spyTypes";
+import { SpyCallArgs } from "../spies/spyTypes";
 import { CftRequest } from "../types";
 
-export type TestEnvironmentGetter = (request: CftRequest) => TestEnvironment | undefined;
+export type TestFrameworkSelector = (request: CftRequest) => TestFramework | undefined;
 
-export interface TestEnvironment {
-  after: (callback: (hooks: TestAfterHooks) => void) => void;
-  before: (callback: () => void) => void;
-  filterMethodCalls: (filter: MethodCallsAndName) => MethodCall[];
+export interface TestFramework {
+  /**
+   * Adds a callback to be called after each test.
+   *
+   * @param callback - Called after each test.
+   */
+  afterEach: (callback: (hooks?: TestAfterHooks) => void) => void;
+
+  /**
+   * Adds a callback to be called after each test.
+   *
+   * @param callback - Called after each test.
+   */
+  beforeEach: (callback: () => void) => void;
+
+  /**
+   * Maps each spy method name and calls to the args that should be logged.
+   *
+   * @param call - A method call's args and name.
+   * @returns The args that should be logged.
+   * @remarks If not provided, the method calls are returned directly.
+   */
+  mapSpyCalls?: (call: SpyCallsAndName) => SpyCallArgs[];
 }
 
 export interface TestAfterHooks {
-  reportComplaint: (complaint: TestComplaint) => void;
+  reportComplaint?: (complaint: TestComplaint) => void;
 }
 
-export interface MethodCallsAndName {
-  methodCalls: MethodCall[];
+export interface SpyCallsAndName {
+  methodCalls: SpyCallArgs[];
   methodName: string;
 }
 
@@ -26,5 +45,5 @@ export interface MethodCallsAndName {
  */
 export interface TestComplaint {
   error: Error;
-  methodComplaints: MethodCallsAndName[];
+  methodComplaints: SpyCallsAndName[];
 }

--- a/src/spies/fallback.ts
+++ b/src/spies/fallback.ts
@@ -1,16 +1,11 @@
-import { createStack } from "../stack";
+import { SpyCallArgs, SpyFactory } from "./spyTypes";
 
-import { MethodCall, SpyFactory } from "./spyTypes";
-
-export const getFallbackSpyFactory = (): SpyFactory => (container: any, methodName: string) => {
-  const methodCalls: MethodCall[] = [];
+export const selectFallbackSpyFactory = (): SpyFactory => (container: any, methodName: string) => {
+  const methodCalls: SpyCallArgs[] = [];
   const originalMethod = container[methodName];
 
-  const spyMethod = function (this: unknown, ...args: unknown[]) {
-    methodCalls.push({
-      args,
-      stack: createStack(),
-    });
+  const spyMethod = function (this: unknown, ...args: SpyCallArgs) {
+    methodCalls.push(args);
 
     return originalMethod.apply(this, args);
   };

--- a/src/spies/jasmine.ts
+++ b/src/spies/jasmine.ts
@@ -1,7 +1,4 @@
-import { createStack } from "../stack";
-import { CftRequest } from "../types";
-
-import { MethodCall, SpyFactory, SpyFactoryGetter } from "./spyTypes";
+import { SpyCallArgs, SpyFactory, SpyFactoryGetter } from "./spyTypes";
 
 declare interface Jasmine {
   createSpy(): Function & any;
@@ -18,17 +15,13 @@ const isJasmineModule = (spyLibrary: unknown): spyLibrary is Jasmine => {
 
 const createJasmineSpyFactory = (spyLibrary: Jasmine): SpyFactory => {
   return (container: any, methodName: string) => {
-    const methodCalls: MethodCall[] = [];
+    const methodCalls: SpyCallArgs[] = [];
     const originalMethod = container[methodName];
 
     container[methodName] = spyLibrary
       .createSpy()
-      .and.callFake(function (this: unknown, ...args: unknown[]) {
-        methodCalls.push({
-          args,
-          stack: createStack(),
-        });
-
+      .and.callFake(function (this: unknown, ...args: SpyCallArgs) {
+        methodCalls.push(args);
         return originalMethod.apply(this, args);
       });
 
@@ -41,7 +34,7 @@ const createJasmineSpyFactory = (spyLibrary: Jasmine): SpyFactory => {
   };
 };
 
-export const getJasmineSpyFactory: SpyFactoryGetter = ({ spyLibrary }: CftRequest) => {
+export const selectJasmineSpyFactory: SpyFactoryGetter = ({ spyLibrary }) => {
   if (isJasmineModule(spyLibrary)) {
     return createJasmineSpyFactory(spyLibrary);
   }

--- a/src/spies/jest.ts
+++ b/src/spies/jest.ts
@@ -1,7 +1,4 @@
-import { createStack } from "../stack";
-import { CftRequest } from "../types";
-
-import { MethodCall, SpyFactory, SpyFactoryGetter } from "./spyTypes";
+import { SpyCallArgs, SpyFactory, SpyFactoryGetter } from "./spyTypes";
 
 declare interface Jest {
   fn(implementation: Function): void;
@@ -15,15 +12,11 @@ const isJestModule = (spyLibrary: unknown): spyLibrary is Jest => {
 
 const createJestSpyFactory = (spyLibrary: Jest): SpyFactory => {
   return (container: any, methodName: string) => {
-    const methodCalls: MethodCall[] = [];
+    const methodCalls: SpyCallArgs[] = [];
     const originalMethod = container[methodName];
 
-    const methodSpy = function (this: unknown, ...args: unknown[]) {
-      methodCalls.push({
-        args,
-        stack: createStack(),
-      });
-
+    const methodSpy = function (this: unknown, ...args: SpyCallArgs) {
+      methodCalls.push(args);
       return originalMethod.apply(this, args);
     };
 
@@ -38,7 +31,7 @@ const createJestSpyFactory = (spyLibrary: Jest): SpyFactory => {
   };
 };
 
-export const getJestSpyFactory: SpyFactoryGetter = ({ spyLibrary }: CftRequest) => {
+export const selectJestSpyFactory: SpyFactoryGetter = ({ spyLibrary }) => {
   if (isJestModule(spyLibrary)) {
     return createJestSpyFactory(spyLibrary);
   }

--- a/src/spies/selectSpyFactory.ts
+++ b/src/spies/selectSpyFactory.ts
@@ -1,27 +1,27 @@
 import { CftRequest, SupportedSpyLibrary } from "../types";
 
-import { getFallbackSpyFactory } from "./fallback";
-import { getJasmineSpyFactory } from "./jasmine";
-import { getJestSpyFactory } from "./jest";
-import { getSinonSpyFactory } from "./sinon";
-import { SpyFactory, SpyFactoryGetter } from "./spyTypes";
+import { selectFallbackSpyFactory } from "./fallback";
+import { selectJasmineSpyFactory } from "./jasmine";
+import { selectJestSpyFactory } from "./jest";
+import { selectSinonSpyFactory } from "./sinon";
+import { SpyFactoryGetter as SpyFactorySelector } from "./spyTypes";
 
-const spyFactoriesByName = new Map<SupportedSpyLibrary, SpyFactoryGetter>([
-  ["fallback", getFallbackSpyFactory],
-  ["jest", getJestSpyFactory],
-  ["jasmine", getJasmineSpyFactory],
-  ["sinon", getSinonSpyFactory],
+const spyFactoriesByName = new Map<SupportedSpyLibrary, SpyFactorySelector>([
+  ["fallback", selectFallbackSpyFactory],
+  ["jest", selectJestSpyFactory],
+  ["jasmine", selectJasmineSpyFactory],
+  ["sinon", selectSinonSpyFactory],
 ]);
 
-const detectableSpyFactoryGetters: SpyFactoryGetter[] = [
+const detectableSpyFactorySelectors: SpyFactorySelector[] = [
   // Jest should come before Jasmine because Jest includes a monkey-patched Jasmine
-  getJestSpyFactory,
-  getJasmineSpyFactory,
+  selectJestSpyFactory,
+  selectJasmineSpyFactory,
 
-  getSinonSpyFactory,
+  selectSinonSpyFactory,
 ];
 
-export const getSpyFactory = (request: CftRequest): SpyFactory => {
+export const selectSpyFactory = (request: CftRequest) => {
   // If a spy library is requested by name, it must exist
   if (typeof request.spyLibrary === "string") {
     const getter = spyFactoriesByName.get(request.spyLibrary);
@@ -40,7 +40,7 @@ export const getSpyFactory = (request: CftRequest): SpyFactory => {
   }
 
   // Otherwise, attempt to auto-detect an active one
-  for (const getter of detectableSpyFactoryGetters) {
+  for (const getter of detectableSpyFactorySelectors) {
     const library = getter(request);
 
     if (library !== undefined) {
@@ -48,5 +48,5 @@ export const getSpyFactory = (request: CftRequest): SpyFactory => {
     }
   }
 
-  return getFallbackSpyFactory();
+  return selectFallbackSpyFactory();
 };

--- a/src/spies/sinon.ts
+++ b/src/spies/sinon.ts
@@ -1,10 +1,7 @@
-import { createStack } from "../stack";
-import { CftRequest } from "../types";
-
-import { MethodCall, SpyFactory, SpyFactoryGetter } from "./spyTypes";
+import { SpyCallArgs, SpyFactory, SpyFactoryGetter } from "./spyTypes";
 
 type SinonSpy = Function & {
-  getCalls(): unknown[][];
+  getCalls(): SpyCallArgs[];
   restore(): void;
 };
 
@@ -20,15 +17,11 @@ const isSinonModule = (spyLibrary: unknown): spyLibrary is Sinon => {
 
 const createSinonSpyFactory = (spyLibrary: Sinon): SpyFactory => {
   return (container: any, methodName: string) => {
-    const methodCalls: MethodCall[] = [];
+    const methodCalls: SpyCallArgs[] = [];
     const originalMethod = container[methodName];
 
-    const spyMethod = spyLibrary.spy(function (this: unknown, ...args: unknown[]) {
-      methodCalls.push({
-        args,
-        stack: createStack(),
-      });
-
+    const spyMethod = spyLibrary.spy(function (this: unknown, ...args: SpyCallArgs) {
+      methodCalls.push(args);
       return originalMethod.apply(this, args);
     });
 
@@ -43,7 +36,7 @@ const createSinonSpyFactory = (spyLibrary: Sinon): SpyFactory => {
   };
 };
 
-export const getSinonSpyFactory: SpyFactoryGetter = ({ spyLibrary }: CftRequest) => {
+export const selectSinonSpyFactory: SpyFactoryGetter = ({ spyLibrary }) => {
   if (isSinonModule(spyLibrary)) {
     return createSinonSpyFactory(spyLibrary);
   }

--- a/src/spies/spyTypes.ts
+++ b/src/spies/spyTypes.ts
@@ -4,17 +4,20 @@ export type SpyFactoryGetter = (request: CftRequest) => SpyFactory | undefined;
 
 /**
  * Creates method spies that abstract the spy library implementation.
+ *
+ * @param container - An object whose method is to be spied on.
+ * @param methodName - The key of the method to spy on, such as `"log"`.
  */
-export type SpyFactory = (container: any, methodName: string) => MethodSpy;
+export type SpyFactory = (container: unknown, methodName: string) => MethodSpy;
 
 /**
  * Record for a single method being spied upon.
  */
 export interface MethodSpy {
   /**
-   * @returns For each call to the spy, its arguments and stack.
+   * @returns For each call to the spy, its arguments.
    */
-  getCalls(): MethodCall[];
+  getCalls(): SpyCallArgs[];
 
   /**
    * Restores the original method on the container.
@@ -22,7 +25,4 @@ export interface MethodSpy {
   restore(): void;
 }
 
-export interface MethodCall {
-  args: unknown[];
-  stack: string[];
-}
+export type SpyCallArgs = unknown[];

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -1,3 +1,0 @@
-export const createStack = () => {
-  return new Error().stack!.split(/\r\n|\r|\n/g);
-};


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #201
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/console-fail-test/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/console-fail-test/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies an assortment of quality-of-life improvements:

* Removes error stack collection, as it's no longer used
* Moves the _Why?_ explanation up in the README.md and switches the explainer image to a code block
* Trims the README.md text a bit
* Bolsters Documentation.md to explain what those objects are doing
* Cleans up variable names & unnecessary type annotations in code
    * Renames _"getters"_ to _"selectors"_ 