### PR TITLE
fix: use public-facing Vitest spy mock functions

### DIFF
--- a/src/spies/vitest.ts
+++ b/src/spies/vitest.ts
@@ -31,7 +31,7 @@ const createVitestSpyFactory = (spyLibrary: Vitest): SpyFactory => {
 
     return {
       getCalls: () => spy.mock.calls,
-      restore: spy.mock.restore,
+      restore: spy.mockRestore,
     };
   };
 };

--- a/src/spies/vitest.ts
+++ b/src/spies/vitest.ts
@@ -7,8 +7,12 @@ declare interface Vitest {
 }
 
 declare interface ViSpy {
+  mock: ViSpyMock;
+  mockRestore(): void;
+}
+
+declare interface ViSpyMock {
   calls: SpyCallArgs[];
-  restore(): void;
 }
 
 declare const __vitest_index__: Vitest | undefined;
@@ -26,8 +30,8 @@ const createVitestSpyFactory = (spyLibrary: Vitest): SpyFactory => {
     const spy = spyLibrary.vi.spyOn(container, methodName);
 
     return {
-      getCalls: () => spy.calls,
-      restore: spy.restore,
+      getCalls: () => spy.mock.calls,
+      restore: spy.mock.restore,
     };
   };
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #204
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/console-fail-test/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/console-fail-test/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses `.mock.calls` and `.mockRestore` as suggested.