### PR TITLE
fix: don't crash when printing recursive objects

### DIFF
--- a/src/complaining/formatComplaintCall.test.ts
+++ b/src/complaining/formatComplaintCall.test.ts
@@ -7,6 +7,14 @@ describe("formatComplaintCall", () => {
     [[true], "true"],
     [[{}], "{}"],
     [[{ inner: {} }], '{"inner":{}}'],
+    [
+      (() => {
+        const x = { prop: {} };
+        x.prop = x;
+        return [x];
+      })(),
+      "A recursive object with keys: prop",
+    ],
     [[1, "two", [3]], '1, "two", [3]'],
   ])(`formats %p as %p`, (args, expected) => {
     const actual = formatComplaintCall(args);

--- a/src/complaining/formatComplaintCall.ts
+++ b/src/complaining/formatComplaintCall.ts
@@ -1,7 +1,11 @@
 import { SpyCallArgs } from "../spies/spyTypes";
 
 const formatComplaintLineArg = (arg: unknown) => {
-  return JSON.stringify(arg) || JSON.stringify(`${arg}`);
+  try {
+    return JSON.stringify(arg) || JSON.stringify(`${arg}`);
+  } catch {
+    return `A recursive object with keys: ${Object.keys(arg as {}).join(", ")}`;
+  }
 };
 
 export const formatComplaintCall = (call: SpyCallArgs) =>


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #206
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/console-fail-test/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/console-fail-test/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `try`/`catch` fallback for when `JSON.stringify` throws.