### PR TITLE
fix: switch setup.js to ESM setup.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 				"default": "./lib/index.cjs"
 			}
 		},
-		"./setup": "./setup.js"
+		"./setup": "./setup.mjs"
 	},
 	"main": "./lib/index.js",
 	"files": [

--- a/setup.js
+++ b/setup.js
@@ -1,1 +1,0 @@
-require("./lib/cft.js").cft();

--- a/setup.mjs
+++ b/setup.mjs
@@ -1,0 +1,3 @@
+import { cft } from "./lib/cft.js";
+
+cft();


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #597
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/console-fail-test/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/console-fail-test/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Switches the file's CJS `require()` to an ESM `import`, and indicates this should work as ESM in all package types with an explicit `.mjs` extension.