### PR TITLE
feat: split CJS and ESM outputs more formally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: ./.github/actions/prepare
       - run: pnpm build
-      - run: node ./lib/index.js
+      - run: node ./lib/esm/index.js
 
 name: Build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: ./.github/actions/prepare
       - run: pnpm build
-      - run: node ./lib/cjs/index.js
+      - run: node ./lib/cjs/index.cjs
       - run: node ./lib/esm/index.js
 
 name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: ./.github/actions/prepare
       - run: pnpm build
+      - run: node ./lib/cjs/index.js
       - run: node ./lib/esm/index.js
 
 name: Build

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ For example, in a Jest config:
 ```js
 // jest.config.js
 module.exports = {
-	setupFilesAfterEnv: ["console-fail-test/setup.js"],
+	setupFilesAfterEnv: ["console-fail-test/setup.mjs"],
 };
 ```
+
+> If your package only supports CommonJS, you can use `console-fail-test/setup.cjs`.
 
 ### Test Frameworks
 

--- a/cspell.json
+++ b/cspell.json
@@ -20,10 +20,11 @@
 		"npmpackagejsonlintrc",
 		"outro",
 		"packagejson",
+		"postbuild",
 		"quickstart",
-		"whoopsies",
 		"tseslint",
 		"tsup",
+		"whoopsies",
 		"wontfix"
 	]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -100,6 +100,12 @@ export default tseslint.config(
 		},
 	}),
 	{
+		files: ["package.json"],
+		rules: {
+			"package-json/sort-collections": "off",
+		},
+	},
+	{
 		files: ["*.jsonc"],
 		rules: {
 			"jsonc/comma-dangle": "off",

--- a/fixExtensions.js
+++ b/fixExtensions.js
@@ -1,0 +1,11 @@
+import { globIterate } from "glob";
+import fs from "node:fs/promises";
+
+for await (const entry of globIterate("lib/cjs/**/*.cjs")) {
+	await fs.writeFile(
+		entry,
+		(await fs.readFile(entry))
+			.toString()
+			.replaceAll(/require\("(.+)\.js"\);/g, 'require("$1.cjs");'),
+	);
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 			}
 		},
 		"./setup": "./setup.mjs",
-		"./setup.cjs": "./setup.mjs",
+		"./setup.cjs": "./setup.cjs",
 		"./setup.mjs": "./setup.mjs"
 	},
 	"main": "./lib/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -15,17 +15,19 @@
 	"exports": {
 		".": {
 			"import": {
-				"types": "./lib/index.d.ts",
-				"default": "./lib/index.js"
+				"types": "./lib/esm/index.d.ts",
+				"default": "./lib/esm/index.js"
 			},
 			"require": {
-				"types": "./lib/index.d.cts",
-				"default": "./lib/index.cjs"
+				"types": "./lib/cjs/index.d.cts",
+				"default": "./lib/cjs/index.cjs"
 			}
 		},
-		"./setup": "./setup.mjs"
+		"./setup": "./setup.mjs",
+		"./setup.cjs": "./setup.mjs",
+		"./setup.mjs": "./setup.mjs"
 	},
-	"main": "./lib/index.js",
+	"main": "./lib/esm/index.js",
 	"files": [
 		"lib/",
 		"LICENSE.md",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"LICENSE.md",
 		"package.json",
 		"README.md",
+		"setup.cjs",
 		"setup.mjs"
 	],
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 	],
 	"scripts": {
 		"build": "tsup",
+		"postbuild": "node fixExtensions.js",
 		"format": "prettier .",
 		"lint": "eslint . --max-warnings 0",
 		"lint:knip": "knip",
@@ -58,6 +59,7 @@
 		"@release-it/conventional-changelog": "8.0.1",
 		"@types/eslint-plugin-markdown": "2.0.2",
 		"@types/eslint__js": "8.42.3",
+		"@types/node": "^22.3.0",
 		"@vitest/coverage-v8": "2.0.5",
 		"cspell": "8.13.1",
 		"eslint": "8.57.0",
@@ -70,6 +72,7 @@
 		"eslint-plugin-regexp": "2.6.0",
 		"eslint-plugin-vitest": "0.5.4",
 		"eslint-plugin-yml": "1.14.0",
+		"glob": "^11.0.0",
 		"husky": "9.1.4",
 		"jsonc-eslint-parser": "2.4.0",
 		"knip": "5.27.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,12 @@ importers:
       '@types/eslint__js':
         specifier: 8.42.3
         version: 8.42.3
+      '@types/node':
+        specifier: ^22.3.0
+        version: 22.3.0
       '@vitest/coverage-v8':
         specifier: 2.0.5
-        version: 2.0.5(vitest@2.0.5(@types/node@20.12.7))
+        version: 2.0.5(vitest@2.0.5(@types/node@22.3.0))
       cspell:
         specifier: 8.13.1
         version: 8.13.1
@@ -55,10 +58,13 @@ importers:
         version: 2.6.0(eslint@8.57.0)
       eslint-plugin-vitest:
         specifier: 0.5.4
-        version: 0.5.4(eslint@8.57.0)(typescript@5.5.4)(vitest@2.0.5(@types/node@20.12.7))
+        version: 0.5.4(eslint@8.57.0)(typescript@5.5.4)(vitest@2.0.5(@types/node@22.3.0))
       eslint-plugin-yml:
         specifier: 1.14.0
         version: 1.14.0(eslint@8.57.0)
+      glob:
+        specifier: ^11.0.0
+        version: 11.0.0
       husky:
         specifier: 9.1.4
         version: 9.1.4
@@ -67,7 +73,7 @@ importers:
         version: 2.4.0
       knip:
         specifier: 5.27.2
-        version: 5.27.2(@types/node@20.12.7)(typescript@5.5.4)
+        version: 5.27.2(@types/node@22.3.0)(typescript@5.5.4)
       lint-staged:
         specifier: 15.2.8
         version: 15.2.8
@@ -109,7 +115,7 @@ importers:
         version: 7.18.0(eslint@8.57.0)(typescript@5.5.4)
       vitest:
         specifier: 2.0.5
-        version: 2.0.5(@types/node@20.12.7)
+        version: 2.0.5(@types/node@22.3.0)
 
 packages:
 
@@ -953,8 +959,8 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
-  '@types/node@20.12.7':
-    resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
+  '@types/node@22.3.0':
+    resolution: {integrity: sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==}
 
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -1942,6 +1948,11 @@ packages:
     engines: {node: '>=16 || 14 >=14.18'}
     hasBin: true
 
+  glob@11.0.0:
+    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
+    engines: {node: 20 || >=22}
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -2266,6 +2277,10 @@ packages:
     resolution: {integrity: sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==}
     engines: {node: '>=14'}
 
+  jackspeak@4.0.1:
+    resolution: {integrity: sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==}
+    engines: {node: 20 || >=22}
+
   jiti@1.21.6:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
     hasBin: true
@@ -2438,6 +2453,10 @@ packages:
     resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
     engines: {node: 14 || >=16.14}
 
+  lru-cache@11.0.0:
+    resolution: {integrity: sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
@@ -2538,6 +2557,10 @@ packages:
   mimic-response@4.0.0:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -2697,6 +2720,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  package-json-from-dist@1.0.0:
+    resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
+
   package-json-validator@0.6.5:
     resolution: {integrity: sha512-fEG8kM+EfX0j7TbTWAv6/0NRkid0fUHm2afJx35en3+IlrJ6dRQfKUCpuUl/bGM6MvQ0MxAlpaXkJtYVMp0F4A==}
     hasBin: true
@@ -2764,6 +2790,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.0:
+    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
+    engines: {node: 20 || >=22}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3390,8 +3420,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@6.18.2:
+    resolution: {integrity: sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -4268,7 +4298,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.12.7
+      '@types/node': 22.3.0
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -4280,9 +4310,9 @@ snapshots:
 
   '@types/minimatch@5.1.2': {}
 
-  '@types/node@20.12.7':
+  '@types/node@22.3.0':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.18.2
 
   '@types/normalize-package-data@2.4.1': {}
 
@@ -4371,7 +4401,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitest/coverage-v8@2.0.5(vitest@2.0.5(@types/node@20.12.7))':
+  '@vitest/coverage-v8@2.0.5(vitest@2.0.5(@types/node@22.3.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -4385,7 +4415,7 @@ snapshots:
       std-env: 3.7.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.0.5(@types/node@20.12.7)
+      vitest: 2.0.5(@types/node@22.3.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5173,12 +5203,12 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-vitest@0.5.4(eslint@8.57.0)(typescript@5.5.4)(vitest@2.0.5(@types/node@20.12.7)):
+  eslint-plugin-vitest@0.5.4(eslint@8.57.0)(typescript@5.5.4)(vitest@2.0.5(@types/node@22.3.0)):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.5.4)
       eslint: 8.57.0
     optionalDependencies:
-      vitest: 2.0.5(@types/node@20.12.7)
+      vitest: 2.0.5(@types/node@22.3.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5458,6 +5488,15 @@ snapshots:
       minimatch: 9.0.5
       minipass: 7.1.2
       path-scurry: 1.11.1
+
+  glob@11.0.0:
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 4.0.1
+      minimatch: 10.0.1
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.0
+      path-scurry: 2.0.0
 
   glob@7.2.3:
     dependencies:
@@ -5774,6 +5813,12 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jackspeak@4.0.1:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@1.21.6: {}
 
   joycon@3.1.1: {}
@@ -5825,11 +5870,11 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.27.2(@types/node@20.12.7)(typescript@5.5.4):
+  knip@5.27.2(@types/node@22.3.0)(typescript@5.5.4):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
       '@snyk/github-codeowners': 1.1.0
-      '@types/node': 20.12.7
+      '@types/node': 22.3.0
       easy-table: 1.2.0
       enhanced-resolve: 5.17.1
       fast-glob: 3.3.2
@@ -5947,6 +5992,8 @@ snapshots:
 
   lru-cache@10.2.2: {}
 
+  lru-cache@11.0.0: {}
+
   lru-cache@7.18.3: {}
 
   macos-release@3.2.0: {}
@@ -6056,6 +6103,10 @@ snapshots:
   mimic-response@3.1.0: {}
 
   mimic-response@4.0.0: {}
+
+  minimatch@10.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
 
   minimatch@3.1.2:
     dependencies:
@@ -6234,6 +6285,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+  package-json-from-dist@1.0.0: {}
+
   package-json-validator@0.6.5:
     dependencies:
       optimist: 0.6.1
@@ -6307,6 +6360,11 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.2.2
+      minipass: 7.1.2
+
+  path-scurry@2.0.0:
+    dependencies:
+      lru-cache: 11.0.0
       minipass: 7.1.2
 
   path-type@4.0.0: {}
@@ -6912,7 +6970,7 @@ snapshots:
   uglify-js@3.17.4:
     optional: true
 
-  undici-types@5.26.5: {}
+  undici-types@6.18.2: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -6958,13 +7016,13 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@2.0.5(@types/node@20.12.7):
+  vite-node@2.0.5(@types/node@22.3.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.2.11(@types/node@20.12.7)
+      vite: 5.2.11(@types/node@22.3.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6975,16 +7033,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.11(@types/node@20.12.7):
+  vite@5.2.11(@types/node@22.3.0):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
       rollup: 4.19.0
     optionalDependencies:
-      '@types/node': 20.12.7
+      '@types/node': 22.3.0
       fsevents: 2.3.3
 
-  vitest@2.0.5(@types/node@20.12.7):
+  vitest@2.0.5(@types/node@22.3.0):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.5
@@ -7002,11 +7060,11 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.2.11(@types/node@20.12.7)
-      vite-node: 2.0.5(@types/node@20.12.7)
+      vite: 5.2.11(@types/node@22.3.0)
+      vite-node: 2.0.5(@types/node@22.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.12.7
+      '@types/node': 22.3.0
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/setup.cjs
+++ b/setup.cjs
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-undef
+const { cft } = require("./lib/cjs/cft.js");
+
+cft();

--- a/setup.cjs
+++ b/setup.cjs
@@ -1,4 +1,4 @@
 // eslint-disable-next-line no-undef
-const { cft } = require("./lib/cjs/cft.js");
+const { cft } = require("./lib/cjs/cft.cjs");
 
 cft();

--- a/setup.mjs
+++ b/setup.mjs
@@ -1,3 +1,3 @@
-import { cft } from "./lib/cft.js";
+import { cft } from "./lib/esm/cft.js";
 
 cft();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
 	"compilerOptions": {
-		"allowImportingTsExtensions": true,
 		"declaration": true,
 		"declarationMap": true,
 		"esModuleInterop": true,
-		"module": "Preserve",
-		"moduleResolution": "Bundler",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"noEmit": true,
 		"outDir": "lib",
 		"resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,11 @@
 {
 	"compilerOptions": {
+		"allowImportingTsExtensions": true,
 		"declaration": true,
 		"declarationMap": true,
 		"esModuleInterop": true,
-		"module": "NodeNext",
-		"moduleResolution": "NodeNext",
+		"module": "Preserve",
+		"moduleResolution": "Bundler",
 		"noEmit": true,
 		"outDir": "lib",
 		"resolveJsonModule": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,7 +13,7 @@ export default defineConfig([
 		...configEntryBase,
 		format: "cjs",
 		outDir: "lib/cjs",
-		outExtension: () => ({ dts: ".d.ts", js: ".js" }),
+		outExtension: () => ({ dts: ".d.ts", js: ".cjs" }),
 	},
 	{
 		...configEntryBase,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,11 +1,23 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
+const configEntryBase = {
 	bundle: false,
 	clean: true,
 	dts: true,
 	entry: ["src/**/*.ts", "!src/**/*.test.*"],
-	format: ["cjs", "esm"],
-	outDir: "lib",
 	sourcemap: true,
-});
+};
+
+export default defineConfig([
+	{
+		...configEntryBase,
+		format: "cjs",
+		outDir: "lib/cjs",
+		outExtension: () => ({ dts: ".d.ts", js: ".js" }),
+	},
+	{
+		...configEntryBase,
+		format: "esm",
+		outDir: "lib/esm",
+	},
+]);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #706
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/console-fail-test/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/console-fail-test/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Previously, all outputs were in one `lib/` directory. Now they're in `lib/cjs` and `lib/esm`. This way the package & its consumers don't have to deal with ambiguities in imports/requires around file extensions.

💖 
